### PR TITLE
opentelemetry-instrumentation-chromadb 0.49.6 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-chromadb" %}
-{% set version = "0.47.2" %}
+{% set version = "0.49.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 6dcc5ed2c2d002c6dca0ae29beff11938ff754cac5c54e44a95631b15a526067
+  sha256: 3bd805b1333028e6470765080f49d6a14129a76a81da8ddf3d284f1970e5ef8d
 
 build:
   number: 0
@@ -22,9 +22,9 @@ requirements:
 
   run:
     - python
-    - opentelemetry-api >=1.28.0,<2.0.0
-    - opentelemetry-semantic-conventions >=0.50b0
-    - opentelemetry-instrumentation >=0.50b0
+    - opentelemetry-api >=1.38.0,<2.0.0
+    - opentelemetry-semantic-conventions >=0.59b0
+    - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5
   run_constrained:
     - chromadb >=0.5.0,<0.6.0


### PR DESCRIPTION
opentelemetry-instrumentation-chromadb 0.49.6 

**Destination channel:** Defaults

### Links

- [PKG-11111]
- dev_url:        https://github.com/traceloop/openllmetry/tree/0.49.6
- conda_forge:    https://github.com/conda-forge/opentelemetry-instrumentation-chromadb-feedstock
- pypi:           https://pypi.org/project/opentelemetry-instrumentation-chromadb/0.49.6
- pypi inspector: https://inspector.pypi.io/project/opentelemetry-instrumentation-chromadb/0.49.6

### Explanation of changes:

- new version number


[PKG-11111]: https://anaconda.atlassian.net/browse/PKG-11111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ